### PR TITLE
Add force_check_belongs_to_association option

### DIFF
--- a/lib/cavalry.rb
+++ b/lib/cavalry.rb
@@ -22,15 +22,14 @@ module Cavalry
       errors.blank?
     end
 
+    def config
+      @config ||= Config.new
+    end
 
     private
 
     def client
       @client ||= Client.new(config)
-    end
-
-    def config
-      @config ||= Config.new
     end
   end
 end

--- a/lib/cavalry/config.rb
+++ b/lib/cavalry/config.rb
@@ -6,6 +6,8 @@ module Cavalry
     # Defines validator definition path. files required with **/*.rb
     mattr_accessor :validators_path
 
+    mattr_accessor :force_check_belongs_to_association
+
     def load_models
       load_rb_files(models_path)
     end

--- a/lib/cavalry/validator/each_validator.rb
+++ b/lib/cavalry/validator/each_validator.rb
@@ -9,6 +9,7 @@ module Cavalry
       end
 
       def validate
+        install_force_check_belongs_to_association if Cavalry.config.force_check_belongs_to_association && @source_class.respond_to?(:reflections)
         source_class.all.flat_map {|record| validate_record(record) }.compact
       end
 
@@ -17,6 +18,16 @@ module Cavalry
       def validate_record(record)
         return if record.valid?
         record
+      end
+
+      def install_force_check_belongs_to_association
+        return unless defined?(ActiveRecord::Reflection::BelongsToReflection)
+
+        @source_class.class_eval do
+          reflections.values.select { |r| r.is_a?(ActiveRecord::Reflection::BelongsToReflection) }.each do |r|
+            validates r.name, presence: true
+          end
+        end
       end
     end
   end

--- a/lib/cavalry/version.rb
+++ b/lib/cavalry/version.rb
@@ -1,3 +1,3 @@
 module Cavalry
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Add ability to auto check all belongs_to associations for ActiveRecord without definition at Cavalry::Validator.