### PR TITLE
EachValidators are now preinstall without validate_each definition

### DIFF
--- a/lib/cavalry/validator.rb
+++ b/lib/cavalry/validator.rb
@@ -8,10 +8,12 @@ module Cavalry
         @klasses = klasses.map { |k| append_required_module(k) }
         @each_validators = []
         @group_validators = []
+
+        allocate_each_validators
       end
 
       def validate_each(&block)
-        @each_validators += @klasses.map {|k| EachValidator.new(k, &block) }
+        @each_validators.each {|v| v.append(&block) }
       end
 
       def validate_group(&block)
@@ -34,6 +36,10 @@ module Cavalry
           klass.include(ActiveModel::Validations)
         end
         klass
+      end
+
+      def allocate_each_validators
+        @each_validators += @klasses.map {|k| EachValidator.new(k) }
       end
     end
   end

--- a/lib/cavalry/validator/each_validator.rb
+++ b/lib/cavalry/validator/each_validator.rb
@@ -3,8 +3,11 @@ module Cavalry
     class EachValidator
       attr_reader :source_class
 
-      def initialize(klass, &block)
+      def initialize(klass)
         @source_class = klass
+      end
+
+      def append(&block)
         @source_class.class_eval(&block)
       end
 

--- a/lib/cavalry/version.rb
+++ b/lib/cavalry/version.rb
@@ -1,3 +1,3 @@
 module Cavalry
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/cavalry_spec.rb
+++ b/spec/cavalry_spec.rb
@@ -52,6 +52,44 @@ RSpec.describe Cavalry do
     end
   end
 
+  class Rabbit
+    attr_reader :id
+    attr_reader :name
+
+    def initialize(id, name)
+      @id = id
+      @name = name
+    end
+
+    def attributes
+      {
+        id: id,
+        name: name
+      }
+    end
+
+    # association mock
+    def carrot
+      nil
+    end
+
+    class << self
+      def all
+        @records ||= [].tap do |records|
+          records << new(1, "usagi")
+        end
+      end
+
+      def reflections
+        {
+          carrot: OpenStruct.new(name: :carrot)
+        }
+      end
+    end
+  end
+
+
+
   class Cow
     attr_reader :id
     attr_reader :name
@@ -126,6 +164,12 @@ RSpec.describe Cavalry do
     end
   end
 
+  class RabbitValidator < Cavalry::Validator
+    validate_for Rabbit
+
+    # do not define validate_each to check force belongs_to
+  end
+
   class CowValidator < Cavalry::Validator
     validate_for Cow
 
@@ -161,7 +205,6 @@ RSpec.describe Cavalry do
       end
     end
   end
-
 
   describe "Cavalry.run" do
     subject { Cavalry.run }
@@ -249,13 +292,22 @@ RSpec.describe Cavalry do
           errors: {
             carrot: ["can't be blank"]
           }
+        },
+        {
+          record: "Rabbit",
+          attributes: {
+            id: 1,
+            name: "usagi"
+          },
+          errors: {
+            carrot: ["can't be blank"]
+          }
         }
       ]
-
     end
 
     it "can receive errors with Horse's association error" do
-      expect(subject).to eq(belongs_to_errors + validation_error)
+      expect(subject).to match_array(belongs_to_errors + validation_error)
     end
   end
 end


### PR DESCRIPTION
Now you can define force belongs_to validation without `validate_each`.
And you can define `validate_each` multiple times